### PR TITLE
Fix TileGrid refactor fallout

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -923,7 +923,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f5f2e467e52f6546ae7692b2ab98d35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  tileController: {fileID: 1859153606}
+  tileGrid: {fileID: 1859153606}
   thingPool: {fileID: 1859153607}
   spawnerData: {fileID: 11400000, guid: 0109acc0d1035e446b1d16eb8df467a9, type: 2}
   destinationData: {fileID: 11400000, guid: 9ff085e982caa11429ab5c14bb461946, type: 2}
@@ -957,7 +957,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mainCamera: {fileID: 519420031}
-  tileController: {fileID: 1859153606}
+  tileGrid: {fileID: 1859153606}
 --- !u!114 &1859153606
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -181,7 +181,7 @@ public class GameController : MonoBehaviour
             attempts++;
             if (tile == null) continue; // guard against null tile
 
-        } while (tile.IsOccupied && attempts < maxAttempts);
+        } while (tile.isOccupied && attempts < maxAttempts);
 
         if (attempts >= maxAttempts)
         {
@@ -204,7 +204,7 @@ public class GameController : MonoBehaviour
             Debug.LogError("Failed to find a valid position for the destination.");
             return;
         }
-        Destination destination = DestinationFactory.CreateDestination(destinationData, destinationPosition, color, routeColor, this);
+        Destination destination = DestinationFactory.CreateDestination(destinationData, destinationPosition, thingPool, color);
         tileObjectMap.TryAddTileObject(destination, destinationPosition);
 
 
@@ -215,6 +215,7 @@ public class GameController : MonoBehaviour
             Debug.LogError("Failed to find a valid position for the spawner.");
             return;
         }
-        SpawnerFactory.CreateSpawner(spawnerData, thingPool, destination, this, spawnerPosition, color, routeColor);
+        Vector2Int spawnDirection = GetRandomSpawnDirection();
+        SpawnerFactory.CreateSpawner(spawnerData, spawnerPosition, spawnDirection, thingPool, destination, this, color);
     }
 }

--- a/Assets/Scripts/TileController.cs.meta
+++ b/Assets/Scripts/TileController.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 9f5411c3c87ce454aa23a96b45570b9e

--- a/Assets/Scripts/TileGrid.cs
+++ b/Assets/Scripts/TileGrid.cs
@@ -63,6 +63,9 @@ public class TileGrid : MonoBehaviour
             case TileType.Down: return downTileSprite;
             case TileType.Right: return rightTileSprite;
             case TileType.Left: return leftTileSprite;
+            case TileType.Wall: return wallTileSprite;
+            case TileType.Spawner: return spawnerTileSprite;
+            case TileType.Destination: return destinationTileSprite;
             default: return null; // or a default sprite
         }
     }


### PR DESCRIPTION
## Summary
- fix tileGrid references in scene and code
- update GetRandomValidPosition and spawner creation
- add missing sprite cases for TileGrid
- remove old TileController script

## Testing
- `mcs $(find Assets/Scripts -name '*.cs') -target:library -out:/tmp/test.dll` *(fails: Feature `default literal` not part of C# 7.0 language spec)*

------
https://chatgpt.com/codex/tasks/task_e_68799329a91c832db6777c01dcce235d